### PR TITLE
Mods to accommodate BigQuery

### DIFF
--- a/llama_index/indices/struct_store/sql_query.py
+++ b/llama_index/indices/struct_store/sql_query.py
@@ -354,7 +354,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
                 table_info = self._sql_database.get_single_table_info(table_str)
 
                 if self._context_query_kwargs.get(table_str, None) is not None:
-                    table_opt_context = " The table description is: "
+                    table_opt_context = "" # The table description is: "
                     table_opt_context += self._context_query_kwargs[table_str]
                     table_info += table_opt_context
 
@@ -367,7 +367,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
                 table_info = self._sql_database.get_single_table_info(table_name)
 
                 if self._context_query_kwargs.get(table_name, None) is not None:
-                    table_opt_context = " The table description is: "
+                    table_opt_context = "" # The table description is: "
                     table_opt_context += self._context_query_kwargs[table_name]
                     table_info += table_opt_context
 
@@ -422,7 +422,7 @@ class SQLTableRetrieverQueryEngine(BaseSQLTableQueryEngine):
             )
 
             if table_schema_obj.context_str:
-                table_opt_context = " The table description is: "
+                table_opt_context = "" # The table description is: "
                 table_opt_context += table_schema_obj.context_str
                 table_info += table_opt_context
 


### PR DESCRIPTION
SQLalchemy's BigQuery dialect doesn't support foreign or primary key retrieval. I've modified the code so that these relationships can be described neatly (and in just the same way as llamaindex would like to be able to do it) by altering "table description".
I also added some code to allow selection of specific columns in BQ tables conditional on existence of column description/comment metadata (which can be added via BQ console). These descriptions are then included within context by the SQL query engine.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
